### PR TITLE
Feature/3 query data

### DIFF
--- a/app/scripts/actions/index.js
+++ b/app/scripts/actions/index.js
@@ -1,8 +1,13 @@
+import fetch from 'isomorphic-fetch';
+import config from '../config';
+
 export const UPDATE_SELECTION = 'UPDATE_SELECTION';
 export const UNDO = 'UNDO';
 export const REDO = 'REDO';
 export const COMPLETE_UNDO = 'COMPLETE_UNDO';
 export const COMPLETE_REDO = 'COMPLETE_REDO';
+export const COMPLETE_MAP_UPDATE = 'COMPLETE_MAP_UPDATE';
+export const UPDATE_MAP_DATA = 'UPDATE_MAP_DATA';
 
 export function updateSelection (selectionArray) {
   return { type: UPDATE_SELECTION, data: selectionArray };
@@ -22,4 +27,20 @@ export function completeUndo () {
 
 export function completeRedo () {
   return { type: COMPLETE_REDO };
+}
+
+export function completeMapUpdate () {
+  return { type: COMPLETE_MAP_UPDATE };
+}
+
+export function updateMapData (data) {
+  return { type: UPDATE_MAP_DATA, data };
+}
+
+export function fetchMapData (tile) {
+  return (dispatch) => {
+    fetch(`${config.baseUrl}/features/${tile[2]}/${tile[0]}/${tile[1]}`)
+      .then(response => response.json())
+      .then(response => dispatch(updateMapData(response.objects)));
+  };
 }

--- a/app/scripts/actions/index.js
+++ b/app/scripts/actions/index.js
@@ -8,6 +8,7 @@ export const COMPLETE_UNDO = 'COMPLETE_UNDO';
 export const COMPLETE_REDO = 'COMPLETE_REDO';
 export const COMPLETE_MAP_UPDATE = 'COMPLETE_MAP_UPDATE';
 export const UPDATE_MAP_DATA = 'UPDATE_MAP_DATA';
+export const REQUEST_TILE = 'REQUEST_TILE';
 
 export function updateSelection (selectionArray) {
   return { type: UPDATE_SELECTION, data: selectionArray };
@@ -37,8 +38,19 @@ export function updateMapData (data) {
   return { type: UPDATE_MAP_DATA, data };
 }
 
+/**
+  * Tracks already requested tiles
+  * @param {string} tile of the form x/y/z
+  * @returns {Object} Redux action.
+  */
+
+export function requestTile (tile) {
+  return { type: REQUEST_TILE, data: tile };
+}
+
 export function fetchMapData (tile) {
   return (dispatch) => {
+    dispatch(requestTile(tile.join('/')));
     fetch(`${config.baseUrl}/features/${tile[2]}/${tile[0]}/${tile[1]}`)
       .then(response => response.json())
       .then(response => dispatch(updateMapData(response.objects)));

--- a/app/scripts/actions/index.js
+++ b/app/scripts/actions/index.js
@@ -51,7 +51,7 @@ export function requestTile (tile) {
 export function fetchMapData (tile) {
   return (dispatch) => {
     dispatch(requestTile(tile.join('/')));
-    fetch(`${config.baseUrl}/features/${tile[2]}/${tile[0]}/${tile[1]}`)
+    fetch(`${config.baseUrl}/features/${tile[2]}/${tile[0]}/${tile[1]}.json`)
       .then(response => response.json())
       .then(response => dispatch(updateMapData(response.objects)));
   };

--- a/app/scripts/actions/index.js
+++ b/app/scripts/actions/index.js
@@ -53,6 +53,6 @@ export function fetchMapData (tile) {
     dispatch(requestTile(tile.join('/')));
     fetch(`${config.baseUrl}/features/${tile[2]}/${tile[0]}/${tile[1]}.json`)
       .then(response => response.json())
-      .then(response => dispatch(updateMapData(response.objects)));
+      .then(response => dispatch(updateMapData(response)));
   };
 }

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -126,7 +126,10 @@ const Map = React.createClass({
       mapEvent.target.getBounds().toArray(),
       Math.floor(mapEvent.target.getZoom())
     );
-    this.props.dispatch(fetchMapData(coverTile));
+    // only fetch new data if we haven't requested this tile before
+    if (!this.props.map.requestedTiles.has(coverTile.join('/'))) {
+      this.props.dispatch(fetchMapData(coverTile));
+    }
   },
 
   render: function () {

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -7,6 +7,7 @@ import bboxPolygon from 'turf-bbox-polygon';
 import { tiles } from 'tile-cover';
 import { mapboxgl, MapboxDraw } from '../../util/window';
 
+import config from '../../config';
 import drawStyles from './styles/mapbox-draw-styles';
 import { updateSelection, undo, redo, completeUndo, completeRedo } from '../../actions';
 
@@ -61,7 +62,9 @@ const Map = React.createClass({
       });
       this.map.on('moveend', (e) => {
         const coverTile = this.getCoverTile(e.target.getBounds().toArray(), e.target.getZoom());
-        console.log(coverTile);
+        fetch(`${config.baseUrl}/features/${coverTile[2]}/${coverTile[0]}/${coverTile[1]}`)
+          .then(response => response.json())
+          .then(response => console.log(response));
       });
     }
   },

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -9,7 +9,8 @@ import { mapboxgl, MapboxDraw } from '../../util/window';
 
 import { MAP_STATUS } from '../../reducers/map';
 import drawStyles from './styles/mapbox-draw-styles';
-import { updateSelection, undo, redo, completeUndo, completeRedo, fetchMapData } from '../../actions';
+import { updateSelection, undo, redo, completeUndo, completeRedo, fetchMapData,
+  completeMapUpdate } from '../../actions';
 
 const glSupport = glSupported();
 const noGl = (
@@ -90,6 +91,7 @@ const Map = React.createClass({
           this.draw.add(Object.assign({}, value, { id: key }));
         }
       });
+      this.props.dispatch(completeMapUpdate());
     }
   },
 

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -7,9 +7,8 @@ import bboxPolygon from 'turf-bbox-polygon';
 import { tiles } from 'tile-cover';
 import { mapboxgl, MapboxDraw } from '../../util/window';
 
-import config from '../../config';
 import drawStyles from './styles/mapbox-draw-styles';
-import { updateSelection, undo, redo, completeUndo, completeRedo } from '../../actions';
+import { updateSelection, undo, redo, completeUndo, completeRedo, fetchMapData } from '../../actions';
 
 const glSupport = glSupported();
 const noGl = (
@@ -60,11 +59,13 @@ const Map = React.createClass({
           this.selection = e.features;
         }
       });
+      this.map.on('load', (e) => {
+        const coverTile = this.getCoverTile(e.target.getBounds().toArray(), e.target.getZoom());
+        this.props.dispatch(fetchMapData(coverTile));
+      });
       this.map.on('moveend', (e) => {
         const coverTile = this.getCoverTile(e.target.getBounds().toArray(), e.target.getZoom());
-        fetch(`${config.baseUrl}/features/${coverTile[2]}/${coverTile[0]}/${coverTile[1]}`)
-          .then(response => response.json())
-          .then(response => console.log(response));
+        this.props.dispatch(fetchMapData(coverTile));
       });
     }
   },

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -62,12 +62,10 @@ const Map = React.createClass({
         }
       });
       this.map.on('load', (e) => {
-        const coverTile = this.getCoverTile(e.target.getBounds().toArray(), e.target.getZoom());
-        this.props.dispatch(fetchMapData(coverTile));
+        this.loadMapData(e);
       });
       this.map.on('moveend', (e) => {
-        const coverTile = this.getCoverTile(e.target.getBounds().toArray(), e.target.getZoom());
-        this.props.dispatch(fetchMapData(coverTile));
+        this.loadMapData(e);
       });
     }
   },
@@ -123,6 +121,14 @@ const Map = React.createClass({
     return (cover.length === 1)
     ? cover[0]
     : this.getCoverTile(bounds, zoom - 1);
+  },
+
+  loadMapData: function (mapEvent) {
+    const coverTile = this.getCoverTile(
+      mapEvent.target.getBounds().toArray(),
+      Math.floor(mapEvent.target.getZoom())
+    );
+    this.props.dispatch(fetchMapData(coverTile));
   },
 
   render: function () {

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -27,7 +27,7 @@ const Map = React.createClass({
         container: el,
         scrollWheelZoom: false,
         style: 'mapbox://styles/mapbox/satellite-v9',
-        zoom: 11
+        zoom: 14
       });
       const draw = new MapboxDraw({
         styles: drawStyles,
@@ -83,8 +83,8 @@ const Map = React.createClass({
     if (nextProps.map.tempStore) {
       nextProps.map.tempStore.forEach(feature => {
         // only add, no deletes or updates
-        if (!this.draw.get(feature.id)) {
-          this.draw.add(Object.assign({}, feature.object, { id: feature.id }));
+        if (!this.draw.get(feature.properties.id)) {
+          this.draw.add(Object.assign({}, feature, { id: feature.properties.id }));
         }
       });
       this.props.dispatch(completeMapUpdate());

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -7,7 +7,6 @@ import bboxPolygon from 'turf-bbox-polygon';
 import { tiles } from 'tile-cover';
 import { mapboxgl, MapboxDraw } from '../../util/window';
 
-import { MAP_STATUS } from '../../reducers/map';
 import drawStyles from './styles/mapbox-draw-styles';
 import { updateSelection, undo, redo, completeUndo, completeRedo, fetchMapData,
   completeMapUpdate } from '../../actions';
@@ -80,13 +79,12 @@ const Map = React.createClass({
       this.props.dispatch(historyId === 'undo' ? completeUndo() : completeRedo());
     }
 
-    // if we have a dirty store, update the Draw.store with it then mark it as
-    // clean
-    if (nextProps.map.status === MAP_STATUS.DIRTY) {
-      nextProps.map.store.forEach((value, key) => {
-        // like our internal store, only add, no deletes or updates
-        if (!this.draw.get(key)) {
-          this.draw.add(Object.assign({}, value, { id: key }));
+    // if we have a tempStore, update the Draw.store with it then clear
+    if (nextProps.map.tempStore) {
+      nextProps.map.tempStore.forEach(feature => {
+        // only add, no deletes or updates
+        if (!this.draw.get(feature.id)) {
+          this.draw.add(Object.assign({}, feature.object, { id: feature.id }));
         }
       });
       this.props.dispatch(completeMapUpdate());

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -7,6 +7,7 @@ import bboxPolygon from 'turf-bbox-polygon';
 import { tiles } from 'tile-cover';
 import { mapboxgl, MapboxDraw } from '../../util/window';
 
+import { MAP_STATUS } from '../../reducers/map';
 import drawStyles from './styles/mapbox-draw-styles';
 import { updateSelection, undo, redo, completeUndo, completeRedo, fetchMapData } from '../../actions';
 
@@ -79,6 +80,17 @@ const Map = React.createClass({
       });
       this.props.dispatch(historyId === 'undo' ? completeUndo() : completeRedo());
     }
+
+    // if we have a dirty store, update the Draw.store with it then mark it as
+    // clean
+    if (nextProps.map.status === MAP_STATUS.DIRTY) {
+      nextProps.map.store.forEach((value, key) => {
+        // like our internal store, only add, no deletes or updates
+        if (!this.draw.get(key)) {
+          this.draw.add(Object.assign({}, value, { id: key }));
+        }
+      });
+    }
   },
 
   featureUpdate: function (feature, undoOrRedoKey) {
@@ -124,13 +136,15 @@ const Map = React.createClass({
 
   propTypes: {
     dispatch: React.PropTypes.func,
-    selection: React.PropTypes.object
+    selection: React.PropTypes.object,
+    map: React.PropTypes.object
   }
 });
 
 function mapStateToProps (state) {
   return {
-    selection: state.selection
+    selection: state.selection,
+    map: state.map
   };
 }
 

--- a/app/scripts/config/base.js
+++ b/app/scripts/config/base.js
@@ -1,3 +1,4 @@
 module.exports = {
-  environment: 'development'
+  environment: 'development',
+  baseUrl: 'http://localhost:4030'
 };

--- a/app/scripts/reducers/index.js
+++ b/app/scripts/reducers/index.js
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux';
 import selection from './selection';
+import map from './map';
 
 export const reducers = {
-  selection
+  selection,
+  map
 };
 
 export default combineReducers(Object.assign({}, reducers));

--- a/app/scripts/reducers/map.js
+++ b/app/scripts/reducers/map.js
@@ -1,15 +1,21 @@
-import { COMPLETE_MAP_UPDATE, UPDATE_MAP_DATA } from '../actions';
+import { COMPLETE_MAP_UPDATE, UPDATE_MAP_DATA, REQUEST_TILE } from '../actions';
 
 const initial = {
-  tempStore: null
+  tempStore: null,
+  requestedTiles: new Set()
 };
 
 const map = (state = initial, action) => {
   switch (action.type) {
     case COMPLETE_MAP_UPDATE:
-      return { tempStore: null };
+      return { tempStore: null, requestedTiles: state.requestedTiles };
     case UPDATE_MAP_DATA:
-      return { tempStore: action.data };
+      return { tempStore: action.data, requestedTiles: state.requestedTiles };
+    case REQUEST_TILE:
+      return {
+        tempStore: state.tempStore,
+        requestedTiles: new Set(state.requestedTiles).add(action.data, true)
+      };
     default:
       return state;
   }

--- a/app/scripts/reducers/map.js
+++ b/app/scripts/reducers/map.js
@@ -15,7 +15,16 @@ const map = (state = initial, action) => {
     case COMPLETE_MAP_UPDATE:
       return { store: state.store, status: MAP_STATUS.CLEAN };
     case UPDATE_MAP_DATA:
-      return { store: action.data, status: MAP_STATUS.DIRTY };
+      const newStore = new Map(state.store);
+      // for all of the new data, add it to the store only if it wasn't there
+      // before; don't overwrite
+      console.log(action.data);
+      action.data.forEach(f => {
+        if (!newStore.has(f.id)) {
+          newStore.set(f.id, f.object);
+        }
+      });
+      return { store: newStore, status: MAP_STATUS.DIRTY };
     default:
       return state;
   }

--- a/app/scripts/reducers/map.js
+++ b/app/scripts/reducers/map.js
@@ -1,0 +1,24 @@
+import { COMPLETE_MAP_UPDATE, UPDATE_MAP_DATA } from '../actions';
+
+const MAP_STATUS = {
+  CLEAN: 'clean',
+  DIRTY: 'dirty'
+};
+
+const initial = {
+  store: new Map(),
+  status: MAP_STATUS.CLEAN
+};
+
+const map = (state = initial, action) => {
+  switch (action.type) {
+    case COMPLETE_MAP_UPDATE:
+      return { store: state.store, status: MAP_STATUS.CLEAN };
+    case UPDATE_MAP_DATA:
+      return { store: action.data, status: MAP_STATUS.DIRTY };
+    default:
+      return state;
+  }
+};
+
+export default map;

--- a/app/scripts/reducers/map.js
+++ b/app/scripts/reducers/map.js
@@ -1,6 +1,6 @@
 import { COMPLETE_MAP_UPDATE, UPDATE_MAP_DATA } from '../actions';
 
-const MAP_STATUS = {
+export const MAP_STATUS = {
   CLEAN: 'clean',
   DIRTY: 'dirty'
 };
@@ -18,7 +18,6 @@ const map = (state = initial, action) => {
       const newStore = new Map(state.store);
       // for all of the new data, add it to the store only if it wasn't there
       // before; don't overwrite
-      console.log(action.data);
       action.data.forEach(f => {
         if (!newStore.has(f.id)) {
           newStore.set(f.id, f.object);

--- a/app/scripts/reducers/map.js
+++ b/app/scripts/reducers/map.js
@@ -1,29 +1,15 @@
 import { COMPLETE_MAP_UPDATE, UPDATE_MAP_DATA } from '../actions';
 
-export const MAP_STATUS = {
-  CLEAN: 'clean',
-  DIRTY: 'dirty'
-};
-
 const initial = {
-  store: new Map(),
-  status: MAP_STATUS.CLEAN
+  tempStore: null
 };
 
 const map = (state = initial, action) => {
   switch (action.type) {
     case COMPLETE_MAP_UPDATE:
-      return { store: state.store, status: MAP_STATUS.CLEAN };
+      return { tempStore: null };
     case UPDATE_MAP_DATA:
-      const newStore = new Map(state.store);
-      // for all of the new data, add it to the store only if it wasn't there
-      // before; don't overwrite
-      action.data.forEach(f => {
-        if (!newStore.has(f.id)) {
-          newStore.set(f.id, f.object);
-        }
-      });
-      return { store: newStore, status: MAP_STATUS.DIRTY };
+      return { tempStore: action.data };
     default:
       return state;
   }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,8 @@
     "react-router-scroll": "^0.4.1",
     "redux": "^3.6.0",
     "redux-logger": "^2.8.1",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "tile-cover": "^3.0.1",
+    "turf-bbox-polygon": "^3.0.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "hat": "0.0.3",
+    "isomorphic-fetch": "^2.2.1",
     "jsdom": "^9.11.0",
     "mapbox-gl-supported": "^1.2.0",
     "mock-browser": "^0.92.12",


### PR DESCRIPTION
Close #3 

Pulls data from a local store on map load and map move. Only writes additions to the local store and `Draw.store`. Future improvements:
- [x] track which tiles we've fetched data for and don't query
- interrupt pending requests when a new one is issued (maybe? cc: @kamicut )

Update: only storing features in the `Draw.store` (no need to duplicate in a local Redux store)