### PR TITLE
Fix/load tile

### DIFF
--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import c from 'classnames';
-import { get as safeGet } from 'object-path';
 import bboxPolygon from 'turf-bbox-polygon';
 import { point } from '@turf/helpers';
 import lineSlice from '@turf/line-slice';
@@ -187,8 +186,7 @@ export const Map = React.createClass({
   },
 
   loadMapData: function (mapEvent) {
-    const getBounds = safeGet(mapEvent, 'target.getBounds');
-    if (typeof getBounds !== 'function') return;
+    if (!mapEvent.target.getBounds) return;
     const coverTile = this.getCoverTile(
       mapEvent.target.getBounds().toArray(),
       Math.floor(mapEvent.target.getZoom())

--- a/test/map.js
+++ b/test/map.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-vars */
 import React from 'react';
 import test from 'tape';
-import sinon from 'sinon';
 import mock from 'mapbox-gl-js-mock';
 import window, * as global from '../app/scripts/util/window';
 global.glSupport = true;


### PR DESCRIPTION
Fixes a bug from this morning.
I think because `target.event.getBounds` is an inherited property, `object-path#get` doesn't recognize it. Doing it this way instead.
cc @drewbo 