### PR TITLE
Save to store

### DIFF
--- a/app/scripts/actions/index.js
+++ b/app/scripts/actions/index.js
@@ -78,7 +78,7 @@ export function fetchMapData (tile) {
 
 /**
  * Commit changes
-  * @param {array} a set of stored actions to commit
+  * @param {Array} data a set of stored actions to commit
   * @returns {Object} Redux action.
  */
 

--- a/app/scripts/actions/index.js
+++ b/app/scripts/actions/index.js
@@ -1,9 +1,11 @@
 import fetch from 'isomorphic-fetch';
 import config from '../config';
+import compress from '../util/compress-changes';
 
 export const UPDATE_SELECTION = 'UPDATE_SELECTION';
 export const UNDO = 'UNDO';
 export const REDO = 'REDO';
+export const SAVE = 'SAVE';
 export const COMPLETE_UNDO = 'COMPLETE_UNDO';
 export const COMPLETE_REDO = 'COMPLETE_REDO';
 export const COMPLETE_MAP_UPDATE = 'COMPLETE_MAP_UPDATE';
@@ -70,5 +72,39 @@ export function fetchMapData (tile) {
     fetch(`${config.baseUrl}/features/${tile[2]}/${tile[0]}/${tile[1]}.json`)
       .then(response => response.json())
       .then(response => dispatch(updateMapData(response)));
+  };
+}
+
+/**
+ * Commit changes
+  * @param {array} a set of stored actions to commit
+  * @returns {Object} Redux action.
+ */
+
+export function requestSave (data) {
+  return { type: SAVE, data };
+}
+
+const headers = { 'Content-Type': 'application/json' };
+function checkStatus (response) {
+  if (response.status >= 200 && response.status < 300) {
+    return response;
+  } else {
+    var error = new Error(response.statusText);
+    error.response = response;
+    throw error;
+  }
+}
+export function save (past) {
+  const payload = compress(past);
+  return (dispatch) => {
+    dispatch(requestSave({ inflight: true, error: null }));
+    fetch(`${config.baseUrl}/commit`, { headers, method: 'POST', body: JSON.stringify(payload) })
+      .then(checkStatus)
+      .then(response => {
+        dispatch(requestSave({ inflight: false, error: null, success: true }));
+        setTimeout(() => dispatch(requestSave({ infilght: false, success: null })), 500);
+      })
+      .catch(error => dispatch(requestSave({ inflight: false, error })));
   };
 }

--- a/app/scripts/actions/index.js
+++ b/app/scripts/actions/index.js
@@ -1,7 +1,7 @@
 import fetch from 'isomorphic-fetch';
 import config from '../config';
 import compress from '../util/compress-changes';
-import isEmpty from 'lodash.isEmpty';
+import isEmpty from 'lodash.isempty';
 
 export const UPDATE_SELECTION = 'UPDATE_SELECTION';
 export const UNDO = 'UNDO';

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -175,9 +175,8 @@ export const Map = React.createClass({
 
   save: function () {
     const { past } = this.props.selection;
-    if (past.length) {
-      this.props.dispatch(save(past));
-    }
+    const { historyId } = this.props.save;
+    this.props.dispatch(save(past, historyId));
   },
 
   getCoverTile: function (bounds, zoom) {
@@ -233,14 +232,15 @@ export const Map = React.createClass({
 
   render: function () {
     const { save } = this.props;
-    const { past, future } = this.props.selection;
+    const { past, present, future } = this.props.selection;
+    const isSynced = present.historyId === 'initial' || save.historyId === past[past.length - 1].historyId;
     if (!glSupport) { return noGl; }
     return (
       <div className='map__container' ref={this.initMap} id={id}>
         <button className={c({disabled: !past.length})} onClick={this.undo}>Undo</button>
         <button className={c({disabled: !future.length})} onClick={this.redo}>Redo</button>
         <button className={c({active: this.props.draw.mode === SPLIT})} onClick={this.splitMode}>Split</button>
-        <button onClick={this.save} style={{float: 'right', marginRight: '250px'}}>Save</button>
+        <button className={c({disabled: isSynced})} onClick={this.save} style={{float: 'right', marginRight: '250px'}}>Save</button>
         {save.inflight ? <span style={{float: 'right'}}>Saving...</span> : null}
         {save.success ? <span style={{float: 'right'}}>Success!</span> : null}
       </div>

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -12,7 +12,7 @@ import window, { mapboxgl, MapboxDraw, glSupport } from '../../util/window';
 const { document } = window;
 
 import drawStyles from './styles/mapbox-draw-styles';
-import { updateSelection, undo, redo, completeUndo, completeRedo, fetchMapData,
+import { updateSelection, undo, redo, completeUndo, completeRedo, save, fetchMapData,
   completeMapUpdate, changeDrawMode } from '../../actions';
 
 const SPLIT = 'split';
@@ -173,6 +173,13 @@ export const Map = React.createClass({
     this.props.dispatch(redo());
   },
 
+  save: function () {
+    const { past } = this.props.selection;
+    if (past.length) {
+      this.props.dispatch(save(past));
+    }
+  },
+
   getCoverTile: function (bounds, zoom) {
     const limits = { min_zoom: zoom, max_zoom: zoom };
     const feature = bboxPolygon(bounds[0].concat(bounds[1]));
@@ -225,6 +232,7 @@ export const Map = React.createClass({
   },
 
   render: function () {
+    const { save } = this.props;
     const { past, future } = this.props.selection;
     if (!glSupport) { return noGl; }
     return (
@@ -232,6 +240,9 @@ export const Map = React.createClass({
         <button className={c({disabled: !past.length})} onClick={this.undo}>Undo</button>
         <button className={c({disabled: !future.length})} onClick={this.redo}>Redo</button>
         <button className={c({active: this.props.draw.mode === SPLIT})} onClick={this.splitMode}>Split</button>
+        <button onClick={this.save} style={{float: 'right', marginRight: '250px'}}>Save</button>
+        {save.inflight ? <span style={{float: 'right'}}>Saving...</span> : null}
+        {save.success ? <span style={{float: 'right'}}>Success!</span> : null}
       </div>
     );
   },
@@ -240,7 +251,8 @@ export const Map = React.createClass({
     dispatch: React.PropTypes.func,
     selection: React.PropTypes.object,
     map: React.PropTypes.object,
-    draw: React.PropTypes.object
+    draw: React.PropTypes.object,
+    save: React.PropTypes.object
   }
 });
 
@@ -256,7 +268,8 @@ function mapStateToProps (state) {
   return {
     selection: state.selection,
     map: state.map,
-    draw: state.draw
+    draw: state.draw,
+    save: state.save
   };
 }
 

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -238,8 +238,8 @@ export const Map = React.createClass({
 
   render: function () {
     const { save } = this.props;
-    const { past, present, future } = this.props.selection;
-    const isSynced = present.historyId === 'initial' || save.historyId === past[past.length - 1].historyId;
+    const { past, future } = this.props.selection;
+    const isSynced = !past.length || save.historyId === past[past.length - 1].historyId;
     if (!glSupport) { return noGl; }
     return (
       <div className='map__container' ref={this.initMap} id={id}>

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -135,10 +135,16 @@ export const Map = React.createClass({
     const ctrl = ctrlKey || metaKey;
     let isShortcut = true;
     switch (keyCode) {
+
       // z
       case (90):
         if (shiftKey && ctrl && future.length) this.redo();
         else if (ctrl && past.length) this.undo();
+        break;
+
+      // s
+      case (83):
+        if (ctrl) this.save();
         break;
       default:
         isShortcut = false;

--- a/app/scripts/reducers/index.js
+++ b/app/scripts/reducers/index.js
@@ -2,11 +2,13 @@ import { combineReducers } from 'redux';
 import selection from './selection';
 import map from './map';
 import draw from './draw';
+import save from './save';
 
 export const reducers = {
   selection,
   map,
-  draw
+  draw,
+  save
 };
 
 export default combineReducers(Object.assign({}, reducers));

--- a/app/scripts/reducers/save.js
+++ b/app/scripts/reducers/save.js
@@ -2,7 +2,9 @@ import { SAVE } from '../actions';
 
 const initial = {
   inflight: false,
-  error: null
+  error: null,
+  success: null,
+  historyId: null
 };
 
 const save = (state = initial, action) => {

--- a/app/scripts/reducers/save.js
+++ b/app/scripts/reducers/save.js
@@ -1,0 +1,17 @@
+import { SAVE } from '../actions';
+
+const initial = {
+  inflight: false,
+  error: null
+};
+
+const save = (state = initial, action) => {
+  switch (action.type) {
+    case SAVE:
+      return Object.assign({}, state, action.data);
+    default:
+      return state;
+  }
+};
+
+export default save;

--- a/app/scripts/util/compress-changes.js
+++ b/app/scripts/util/compress-changes.js
@@ -1,0 +1,37 @@
+'use strict';
+// compress a series of changes from the store into a smaller format
+export default function compress (selectionArray) {
+  const deleted = {};
+  const edited = {};
+  const created = {};
+  selectionArray.forEach(selectionObj => {
+    const { selection } = selectionObj;
+    selection.forEach(action => {
+      const { id, undo, redo } = action;
+      if (!redo) {
+        // deletion - but don't save it as a delete it's new.
+        if (created[id]) delete created[id];
+        else {
+          deleted[id] = 1;
+          // delete a previous edit if it exists.
+          edited[id] && delete edited[id];
+        }
+      } if (!undo) {
+        // creation - save as such.
+        created[id] = redo;
+      } else {
+        // alteration - check if it's just created, and apply the new change there if so.
+        if (created[id]) created[id] = redo;
+        else edited[id] = redo;
+      }
+    });
+  });
+  return {
+    deleted: Object.keys(deleted),
+    edited: values(edited).concat(values(created))
+  };
+}
+
+function values (obj) {
+  return Object.keys(obj).map(key => obj[key]).filter(Boolean);
+}

--- a/app/scripts/util/compress-changes.js
+++ b/app/scripts/util/compress-changes.js
@@ -7,7 +7,7 @@ export default function compress (selectionArray, lastHistoryId) {
   const edited = {};
   const created = {};
   let index = 0;
-  if (lastHistoryId) {
+  if (typeof lastHistoryId !== 'undefined') {
     index = findIndex(selectionArray, d => d.historyId === lastHistoryId);
     index = index === -1 ? 0 : index + 1;
   }

--- a/app/scripts/util/compress-changes.js
+++ b/app/scripts/util/compress-changes.js
@@ -1,10 +1,18 @@
 'use strict';
+import findIndex from 'lodash.findindex';
+
 // compress a series of changes from the store into a smaller format
-export default function compress (selectionArray) {
+export default function compress (selectionArray, lastHistoryId) {
   const deleted = {};
   const edited = {};
   const created = {};
-  selectionArray.forEach(selectionObj => {
+  let index = 0;
+  if (lastHistoryId) {
+    index = findIndex(selectionArray, d => d.historyId === lastHistoryId);
+    index = index === -1 ? 0 : index + 1;
+  }
+  for (let i = index; i < selectionArray.length; ++i) {
+    const selectionObj = selectionArray[i];
     const { selection } = selectionObj;
     selection.forEach(action => {
       const { id, undo, redo } = action;
@@ -25,7 +33,7 @@ export default function compress (selectionArray) {
         else edited[id] = redo;
       }
     });
-  });
+  }
   return {
     deleted: Object.keys(deleted),
     edited: values(edited).concat(values(created))

--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
     "hat": "0.0.3",
     "isomorphic-fetch": "^2.2.1",
     "jsdom": "^9.11.0",
+    "lodash.findindex": "^4.6.0",
+    "lodash.isempty": "^4.4.0",
     "mapbox-gl-supported": "^1.2.0",
     "mock-browser": "^0.92.12",
     "object-path": "^0.11.4",

--- a/test/compress-changes.js
+++ b/test/compress-changes.js
@@ -1,0 +1,37 @@
+'use strict';
+import test from 'tape';
+import compress from '../app/scripts/util/compress-changes';
+
+test('compression', function (t) {
+  // modification, then deletion
+  let payload = compress([
+    {selection: [{id: 1, redo: 1, undo: 1}]},
+    {selection: [{id: 1, redo: 1, undo: 1}]},
+    {selection: [{id: 1, redo: 1, undo: 1}]},
+    {selection: [{id: 1, redo: 1, undo: 1}]},
+    {selection: [{id: 1, redo: 1, undo: 1}]},
+    {selection: [{id: 1, redo: 1, undo: 1}]},
+    {selection: [{id: 1, redo: 0, undo: 1}]}
+  ]);
+  t.equal(payload.deleted.length, 1);
+  t.equal(payload.edited.length, 0);
+
+  // creation, then deletion
+  payload = compress([
+    {selection: [{id: 1, redo: 1, undo: 0}]},
+    {selection: [{id: 1, redo: 0, undo: 1}]}
+  ]);
+  t.equal(payload.deleted.length, 0);
+  t.equal(payload.edited.length, 0);
+
+  // creation, then modification
+  payload = compress([
+    {selection: [{id: 1, redo: 1, undo: 0}]},
+    {selection: [{id: 1, redo: 2, undo: 1}]}
+  ]);
+  t.equal(payload.deleted.length, 0);
+  t.equal(payload.edited.length, 1);
+  t.equal(payload.edited[0], 2);
+
+  t.end();
+});

--- a/test/compress-changes.js
+++ b/test/compress-changes.js
@@ -33,5 +33,15 @@ test('compression', function (t) {
   t.equal(payload.edited.length, 1);
   t.equal(payload.edited[0], 2);
 
+  // creation, modification, then deletion (but starting from after the creation)
+  // without the historyId param, this would produce an empty payload
+  payload = compress([
+    {historyId: 0, selection: [{id: 1, redo: 1, undo: 0}]},
+    {historyId: 1, selection: [{id: 1, redo: 2, undo: 1}]},
+    {historyId: 2, selection: [{id: 1, redo: 0, undo: 1}]}
+  ], 0);
+  t.equal(payload.deleted.length, 1);
+  t.equal(payload.edited.length, 0);
+
   t.end();
 });

--- a/test/map.js
+++ b/test/map.js
@@ -21,6 +21,7 @@ function setup (options) {
   const props = Object.assign({
     selection: {
       past: [],
+      present: { historyId: 'initial' },
       future: []
     },
     draw: {

--- a/test/map.js
+++ b/test/map.js
@@ -25,7 +25,8 @@ function setup (options) {
     },
     draw: {
       mode: null
-    }
+    },
+    save: {}
   }, options);
   const map = mount(<Map {...props} />);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4553,6 +4553,10 @@ lodash.filter@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
 
+lodash.findindex@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.findindex/-/lodash.findindex-4.6.0.tgz#a3245dee61fb9b6e0624b535125624bb69c11106"
+
 lodash.flatten@^4.2.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
@@ -4569,7 +4573,7 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
-lodash.isempty@^4.2.1:
+lodash.isempty@^4.2.1, lodash.isempty@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
 


### PR DESCRIPTION
Close #20 

- `util/compress-changes` to translate the `selection` store to a format compatible with the scrub-server.
- actions and reducers for save state.
- Save UI in `components/map`.

Note, `compress-changes` takes an optional second argument that functions as a start-from flag, so we don't commit the entire set of changes each time, and only commit what was changed since the last commit.