### PR TITLE
[WIP] Modify map filters directly when toggling line visibility

### DIFF
--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -187,28 +187,7 @@ export const Map = React.createClass({
         this.map.setFilter(hotLayer, [...baseFilter, ['!in', 'user_status'].concat(nextProps.draw.hidden)]);
       }
     });
-
-    // this.draw.getAll().features.forEach((feature, i) => {
-    //   const visible = feature.properties.visibility !== 'none';
-    //   const featureStatus = feature.properties.status ? feature.properties.status : 'incomplete';
-    //
-    //   if (!hiddenLines.length) {
-    //     if (!visible) this.showLine(feature.id);
-    //   } else if (!visible && hiddenLines.indexOf(featureStatus) === -1) {
-    //     this.showLine(feature.id);
-    //   } else if (visible && hiddenLines.indexOf(featureStatus) > -1) {
-    //     this.hideLine(feature.id);
-    //   }
-    // });
   },
-
-  // hideLine: function (featureId) {
-  //   this.draw.setFeatureProperty(featureId, 'visibility', 'none');
-  // },
-  //
-  // showLine: function (featureId) {
-  //   this.draw.setFeatureProperty(featureId, 'visibility', null);
-  // },
 
   featureUpdate: function (feature, undoOrRedoKey) {
     // if we have a geo, replace/add

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -13,6 +13,8 @@ import { environment, existingRoadsSource } from '../../config';
 import g from '../../util/window';
 
 import drawStyles from './styles/mapbox-draw-styles';
+const lineLayers = drawStyles.filter(style => style.type === 'line');
+
 import {
   updateSelection, undo, redo, completeUndo, completeRedo, save, fetchMapData,
   completeMapUpdate, changeDrawMode, toggleVisibility, toggleExistingRoads
@@ -154,7 +156,11 @@ export const Map = React.createClass({
       nextProps.map.tempStore.forEach(feature => {
         // only add, no deletes or updates
         if (!this.draw.get(feature.properties.id)) {
-          this.draw.add(Object.assign({}, feature, { id: feature.properties.id }));
+          const toAdd = Object.assign({}, feature, { id: feature.properties.id });
+          if (!toAdd.properties.hasOwnProperty('status')) {
+            toAdd.properties.status = 'incomplete';
+          }
+          this.draw.add(toAdd);
         }
       });
       this.props.dispatch(completeMapUpdate());
@@ -168,29 +174,41 @@ export const Map = React.createClass({
     }
 
     // line visibility
-    const hiddenLines = nextProps.draw.hidden;
-
-    this.draw.getAll().features.forEach((feature, i) => {
-      const visible = feature.properties.visibility !== 'none';
-      const featureStatus = feature.properties.status ? feature.properties.status : 'incomplete';
-
-      if (!hiddenLines.length) {
-        if (!visible) this.showLine(feature.id);
-      } else if (!visible && hiddenLines.indexOf(featureStatus) === -1) {
-        this.showLine(feature.id);
-      } else if (visible && hiddenLines.indexOf(featureStatus) > -1) {
-        this.hideLine(feature.id);
+    // const hiddenLines = nextProps.draw.hidden;
+    lineLayers.forEach(layer => {
+      const coldLayer = `${layer.id}.cold`;
+      const hotLayer = `${layer.id}.hot`;
+      if (this.map.getLayer(coldLayer)) {
+        const baseFilter = lineLayers.find(l => l.id === layer.id).filter;
+        this.map.setFilter(coldLayer, [...baseFilter, ['!in', 'user_status'].concat(nextProps.draw.hidden)]);
+      }
+      if (this.map.getLayer(hotLayer)) {
+        const baseFilter = lineLayers.find(l => l.id === layer.id).filter;
+        this.map.setFilter(hotLayer, [...baseFilter, ['!in', 'user_status'].concat(nextProps.draw.hidden)]);
       }
     });
+
+    // this.draw.getAll().features.forEach((feature, i) => {
+    //   const visible = feature.properties.visibility !== 'none';
+    //   const featureStatus = feature.properties.status ? feature.properties.status : 'incomplete';
+    //
+    //   if (!hiddenLines.length) {
+    //     if (!visible) this.showLine(feature.id);
+    //   } else if (!visible && hiddenLines.indexOf(featureStatus) === -1) {
+    //     this.showLine(feature.id);
+    //   } else if (visible && hiddenLines.indexOf(featureStatus) > -1) {
+    //     this.hideLine(feature.id);
+    //   }
+    // });
   },
 
-  hideLine: function (featureId) {
-    this.draw.setFeatureProperty(featureId, 'visibility', 'none');
-  },
-
-  showLine: function (featureId) {
-    this.draw.setFeatureProperty(featureId, 'visibility', null);
-  },
+  // hideLine: function (featureId) {
+  //   this.draw.setFeatureProperty(featureId, 'visibility', 'none');
+  // },
+  //
+  // showLine: function (featureId) {
+  //   this.draw.setFeatureProperty(featureId, 'visibility', null);
+  // },
 
   featureUpdate: function (feature, undoOrRedoKey) {
     // if we have a geo, replace/add

--- a/app/scripts/components/map/styles/mapbox-draw-styles.js
+++ b/app/scripts/components/map/styles/mapbox-draw-styles.js
@@ -4,7 +4,7 @@ const styles = [
   {
     'id': 'gl-draw-line-inactive',
     'type': 'line',
-    'filter': ['all', ['==', '$type', 'LineString'], ['!=', 'mode', 'static'], ['==', 'active', 'false'], ['!=', 'user_visibility', 'none']],
+    'filter': ['all', ['==', '$type', 'LineString'], ['!=', 'mode', 'static'], ['==', 'active', 'false']],
     'layout': {
       'line-cap': 'round',
       'line-join': 'round'
@@ -17,7 +17,7 @@ const styles = [
   {
     'id': 'gl-draw-line-active',
     'type': 'line',
-    'filter': ['all', ['==', '$type', 'LineString'], ['!=', 'mode', 'static'], ['==', 'active', 'true'], ['!=', 'user_visibility', 'none']],
+    'filter': ['all', ['==', '$type', 'LineString'], ['!=', 'mode', 'static'], ['==', 'active', 'true']],
     'layout': {
       'line-cap': 'round',
       'line-join': 'round'
@@ -32,7 +32,7 @@ const styles = [
   {
     'id': 'gl-draw-line-inactive-edited',
     'type': 'line',
-    'filter': ['all', ['==', '$type', 'LineString'], ['!=', 'mode', 'static'], ['==', 'active', 'false'], ['==', 'user_status', 'edited'], ['!=', 'user_visibility', 'none']],
+    'filter': ['all', ['==', '$type', 'LineString'], ['!=', 'mode', 'static'], ['==', 'active', 'false'], ['==', 'user_status', 'edited']],
     'layout': {
       'line-cap': 'round',
       'line-join': 'round'
@@ -45,7 +45,7 @@ const styles = [
   {
     'id': 'gl-draw-line-active-edited',
     'type': 'line',
-    'filter': ['all', ['==', '$type', 'LineString'], ['!=', 'mode', 'static'], ['==', 'active', 'true'], ['==', 'user_status', 'edited'], ['!=', 'user_visibility', 'none']],
+    'filter': ['all', ['==', '$type', 'LineString'], ['!=', 'mode', 'static'], ['==', 'active', 'true'], ['==', 'user_status', 'edited']],
     'layout': {
       'line-cap': 'round',
       'line-join': 'round'
@@ -59,7 +59,7 @@ const styles = [
   {
     'id': 'gl-draw-line-inactive-complete',
     'type': 'line',
-    'filter': ['all', ['==', '$type', 'LineString'], ['!=', 'mode', 'static'], ['==', 'active', 'false'], ['==', 'user_status', 'complete'], ['!=', 'user_visibility', 'none']],
+    'filter': ['all', ['==', '$type', 'LineString'], ['!=', 'mode', 'static'], ['==', 'active', 'false'], ['==', 'user_status', 'complete']],
     'layout': {
       'line-cap': 'round',
       'line-join': 'round'
@@ -72,7 +72,7 @@ const styles = [
   {
     'id': 'gl-draw-line-active-complete',
     'type': 'line',
-    'filter': ['all', ['==', '$type', 'LineString'], ['!=', 'mode', 'static'], ['==', 'active', 'true'], ['==', 'user_status', 'complete'], ['!=', 'user_visibility', 'none']],
+    'filter': ['all', ['==', '$type', 'LineString'], ['!=', 'mode', 'static'], ['==', 'active', 'true'], ['==', 'user_status', 'complete']],
     'layout': {
       'line-cap': 'round',
       'line-join': 'round'
@@ -131,17 +131,6 @@ const styles = [
       'circle-color': '#FFF'
     }
   },
-  // line visibility
-  {
-    'id': 'gl-draw-visibility',
-    'type': 'line',
-    'filter': ['==', 'user_visibility', 'none'],
-    'visibility': 'none',
-    'paint': {
-      'line-opacity': 0
-    }
-  },
-
   // INACTIVE (static, already drawn)
   {
     'id': 'gl-draw-line-vertex-static',


### PR DESCRIPTION
@sethvincent @dereklieu over the new area, we load a lot of features which led to pretty slow performance especially when updating feature visibility. I didn't do a real profiling but my suspicion is the constant updating via `this.draw.getAll().features.forEach` triggers tons of re-renders. I made two changes:
1. Explicitly add `status = 'incomplete'` for added features without a status
2. Rather than update any features on visibility toggle, directly edit the layer filters via `this.map.setFilter`

Let me know if either of you can take a look, it still needs a little work but I think this will be a big performance gain.