### PR TITLE
Set minzoom

### DIFF
--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -212,6 +212,7 @@ export const Map = React.createClass({
     if ((nextProps.draw.mode === INACTIVE || this.props.draw.mode === INACTIVE) &&
         nextProps.draw.mode !== this.props.draw.mode) {
       this.toggleVisibility('all');
+      this.draw.changeMode('simple_select', { featureIds: [] });
     }
   },
 

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -515,73 +515,78 @@ export const Map = React.createClass({
             </div>
           </div>
         )}
+
         <div className='tool-bar'>
+          {uiDisabled ? <span /> : (
+            <fieldset className='tools'>
+              <legend>Tools</legend>
+              <ul>
+                <li className='tool--line tool__item' onClick={this.newLineMode}>
+                  <a href="#">
+                    <img alt='Add Line' src='../graphics/layout/icon-line.svg' />
+                  </a>
+                  {this.help('top', 'd')}
+                </li>
+                <li
+                  className={c('tool--line-add tool__item',
+                  { disabled: !this.draw || (this.draw && !this.isLineContinuationValid() && this.props.draw.mode !== CONTINUE) },
+                  { active: this.props.draw.mode === CONTINUE }
+                  )}
+                  onClick={this.lineContinuationMode}
+                  >
+                  <a href="#">
+                    <img alt='Add Point' src='../graphics/layout/icon-addline.svg' />
+                  </a>
+                  {this.help('top', 'c')}
+                </li>
+                <li className={c('tool--cut tool__item', {active: this.props.draw.mode === SPLIT})}>
+                  <a onClick={this.splitMode} href="#">
+                    <img alt='Split Line' src='../graphics/layout/icon-cut.svg' />
+                  </a>
+                  {this.help('bottom', 's')}
+                </li>
+                <li className='tool--trash tool__item' onClick={this.delete}>
+                  <a href="#">
+                    <img alt='delete' src='../graphics/layout/icon-trash.svg' />
+                  </a>
+                  {this.help('bottom', 'del')}
+                </li>
+              </ul>
+            </fieldset>
+          )}
 
-          <fieldset className='tools'>
-            <legend>Tools</legend>
-            <ul>
-              <li className='tool--line tool__item' onClick={this.newLineMode}>
-                <a href="#">
-                  <img alt='Add Line' src='../graphics/layout/icon-line.svg' />
-                </a>
-                {this.help('top', 'd')}
-              </li>
-              <li
-                className={c('tool--line-add tool__item',
-                { disabled: !this.draw || (this.draw && !this.isLineContinuationValid() && this.props.draw.mode !== CONTINUE) },
-                { active: this.props.draw.mode === CONTINUE }
-                )}
-                onClick={this.lineContinuationMode}
-                >
-                <a href="#">
-                  <img alt='Add Point' src='../graphics/layout/icon-addline.svg' />
-                </a>
-                {this.help('top', 'c')}
-              </li>
-              <li className={c('tool--cut tool__item', {active: this.props.draw.mode === SPLIT})}>
-                <a onClick={this.splitMode} href="#">
-                  <img alt='Split Line' src='../graphics/layout/icon-cut.svg' />
-                </a>
-                {this.help('bottom', 's')}
-              </li>
-              <li className='tool--trash tool__item' onClick={this.delete}>
-                <a href="#">
-                  <img alt='delete' src='../graphics/layout/icon-trash.svg' />
-                </a>
-                {this.help('bottom', 'del')}
-              </li>
-            </ul>
-          </fieldset>
+          {uiDisabled ? <span /> : (
+            <fieldset className='toggle'>
+              <legend>Predicted Road Layers</legend>
+              <ul>
+                <li className='toggle__item toggle__all'>
+                  <a className={c({showall: hidden.length >= 1})} href="#" onClick={this.toggleVisibility.bind(this, 'all')}>
+                    <icon className='visibility'><span>Hide/Show</span></icon>
+                    <span className='line-description'>All Predicted</span>
+                  </a>
+                </li>
+                <li className='toggle__item'>
+                  <a className={c({showall: hidden.indexOf(INCOMPLETE) > -1})} href="#" onClick={this.toggleVisibility.bind(this, INCOMPLETE)}>
+                    <icon className='visibility'><span>Hide/Show</span></icon>
+                    <span className='line__item line--incomplete line-description'>Incomplete</span>
+                  </a>
+                </li>
+                <li className='toggle__item'>
+                  <a className={c({showall: hidden.indexOf(EDITED) > -1})} href="#" onClick={this.toggleVisibility.bind(this, EDITED)}>
+                    <icon className='visibility'><span>Hide/Show</span></icon>
+                    <span className='line-description line__item line--progress'>In Progress</span>
+                  </a>
+                </li>
+                <li className='toggle__item'>
+                  <a className={c({showall: hidden.indexOf(COMPLETE) > -1})} href="#" onClick={this.toggleVisibility.bind(this, COMPLETE)}>
+                    <icon className='visibility'><span>Hide/Show</span></icon>
+                    <span className='line-description line__item line--complete'>Complete</span>
+                  </a>
+                </li>
+              </ul>
+            </fieldset>
+          )}
 
-          <fieldset className='toggle'>
-            <legend>Predicted Road Layers</legend>
-            <ul>
-              <li className='toggle__item toggle__all'>
-                <a className={c({showall: hidden.length >= 1})} href="#" onClick={this.toggleVisibility.bind(this, 'all')}>
-                  <icon className='visibility'><span>Hide/Show</span></icon>
-                  <span className='line-description'>All Predicted</span>
-                </a>
-              </li>
-              <li className='toggle__item'>
-                <a className={c({showall: hidden.indexOf(INCOMPLETE) > -1})} href="#" onClick={this.toggleVisibility.bind(this, INCOMPLETE)}>
-                  <icon className='visibility'><span>Hide/Show</span></icon>
-                  <span className='line__item line--incomplete line-description'>Incomplete</span>
-                </a>
-              </li>
-              <li className='toggle__item'>
-                <a className={c({showall: hidden.indexOf(EDITED) > -1})} href="#" onClick={this.toggleVisibility.bind(this, EDITED)}>
-                  <icon className='visibility'><span>Hide/Show</span></icon>
-                  <span className='line-description line__item line--progress'>In Progress</span>
-                </a>
-              </li>
-              <li className='toggle__item'>
-                <a className={c({showall: hidden.indexOf(COMPLETE) > -1})} href="#" onClick={this.toggleVisibility.bind(this, COMPLETE)}>
-                  <icon className='visibility'><span>Hide/Show</span></icon>
-                  <span className='line-description line__item line--complete'>Complete</span>
-                </a>
-              </li>
-            </ul>
-          </fieldset>
           <fieldset className='toggle'>
             <legend>Existing Road Network Layers</legend>
             <ul>

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -483,7 +483,7 @@ export const Map = React.createClass({
         {uiDisabled ? (
           <div className='menubar menubar--disabled'>
             <div className='row'>
-              <p>Zoom in to edit</p>
+              <button className='button button-base' onClick={() => this.map.zoomTo(minTileZoom)}>Zoom to edit</button>
             </div>
           </div>
         ) : (

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -328,7 +328,7 @@ export const Map = React.createClass({
   },
 
   loadMapData: function (mapEvent) {
-    if (!mapEvent.target.getBounds) return;
+    if (!mapEvent.target.getBounds || this.props.draw.mode === INACTIVE) return;
     const coverTile = this.getCoverTile(
       mapEvent.target.getBounds().toArray(),
       Math.floor(mapEvent.target.getZoom())

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -207,6 +207,12 @@ export const Map = React.createClass({
         this.map.setFilter(hotLayer, [...baseFilter, ['!in', 'user_status'].concat(nextProps.draw.hidden)]);
       }
     });
+
+    // toggle predictions layers when map mode changes from inactive to anything else
+    if ((nextProps.draw.mode === INACTIVE || this.props.draw.mode === INACTIVE)
+        && nextProps.draw.mode !== this.props.draw.mode) {
+      this.toggleVisibility('all');
+    }
   },
 
   featureUpdate: function (feature, undoOrRedoKey) {

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -209,8 +209,8 @@ export const Map = React.createClass({
     });
 
     // toggle predictions layers when map mode changes from inactive to anything else
-    if ((nextProps.draw.mode === INACTIVE || this.props.draw.mode === INACTIVE)
-        && nextProps.draw.mode !== this.props.draw.mode) {
+    if ((nextProps.draw.mode === INACTIVE || this.props.draw.mode === INACTIVE) &&
+        nextProps.draw.mode !== this.props.draw.mode) {
       this.toggleVisibility('all');
     }
   },
@@ -475,37 +475,46 @@ export const Map = React.createClass({
     const status = !statuses.length ? null
       : statuses.length > 1 ? MULTIPLE : statuses[0];
     const hidden = this.props.draw.hidden;
+    const uiDisabled = this.props.draw.mode === INACTIVE;
     const showExistingRoads = this.props.map.showExistingRoads;
 
     return (
       <div className='map__container' ref={this.initMap} id={id}>
-        <div className='menubar'>
-          <div className='row'>
-            <ul>
-              <li className={c({ disabled: !selectedFeatures.length })}>
-                <label>Line Status</label>
-                <div className={c('select-wrapper')}>
-                  <select value={status || ''} onChange={this.setLineStatus}>
-                    {!selectedFeatures.length && <option value=''></option>}
-                    {status === MULTIPLE && <option value={MULTIPLE}>Multiple</option>}
-                    <option value={INCOMPLETE}>Incomplete</option>
-                    <option value={EDITED}>In Progress</option>
-                    <option value={COMPLETE}>Complete</option>
-                  </select>
-                </div>
-              </li>
-              <li>
-                <button className={c({disabled: !past.length}, 'button button-undo button--outline')} onClick={this.undo}>Undo{this.help('bottom', 'ctrl+z')}</button>
-                <button className={c({disabled: !future.length}, 'button button-redo button--outline')} onClick={this.redo}>Redo{this.help('bottom', 'ctrl+shift+z')}</button>
-              </li>
-              <li>
-                <button className={c({disabled: isSynced}, 'button button-base')} onClick={this.save}>SAVE CHANGES{this.help('bottom', 'ctrl+s')}</button>
-                {save.inflight ? <span style={{float: 'right'}}>Saving...</span> : null}
-                {save.success ? <span style={{float: 'right'}}>Success!</span> : null}
-              </li>
-            </ul>
+        {uiDisabled ? (
+          <div className='menubar menubar--disabled'>
+            <div className='row'>
+              <p>Zoom in to edit</p>
+            </div>
           </div>
-        </div>
+        ) : (
+          <div className='menubar'>
+            <div className='row'>
+              <ul>
+                <li className={c({ disabled: !selectedFeatures.length })}>
+                  <label>Line Status</label>
+                  <div className={c('select-wrapper')}>
+                    <select value={status || ''} onChange={this.setLineStatus}>
+                      {!selectedFeatures.length && <option value=''></option>}
+                      {status === MULTIPLE && <option value={MULTIPLE}>Multiple</option>}
+                      <option value={INCOMPLETE}>Incomplete</option>
+                      <option value={EDITED}>In Progress</option>
+                      <option value={COMPLETE}>Complete</option>
+                    </select>
+                  </div>
+                </li>
+                <li>
+                  <button className={c({disabled: !past.length}, 'button button-undo button--outline')} onClick={this.undo}>Undo{this.help('bottom', 'ctrl+z')}</button>
+                  <button className={c({disabled: !future.length}, 'button button-redo button--outline')} onClick={this.redo}>Redo{this.help('bottom', 'ctrl+shift+z')}</button>
+                </li>
+                <li>
+                  <button className={c({disabled: isSynced}, 'button button-base')} onClick={this.save}>SAVE CHANGES{this.help('bottom', 'ctrl+s')}</button>
+                  {save.inflight ? <span style={{float: 'right'}}>Saving...</span> : null}
+                  {save.success ? <span style={{float: 'right'}}>Success!</span> : null}
+                </li>
+              </ul>
+            </div>
+          </div>
+        )}
         <div className='tool-bar'>
 
           <fieldset className='tools'>

--- a/app/scripts/components/map/index.js
+++ b/app/scripts/components/map/index.js
@@ -287,7 +287,12 @@ export const Map = React.createClass({
     features.forEach(this.markAsEdited);
     // reset draw mode in case we were in CONTINUE; remove this after line
     // continuation doesn't fire a create event
-    this.props.dispatch(changeDrawMode(null));
+    const zoom = this.map.getZoom();
+    if (zoom < minTileZoom) {
+      this.props.dispatch(changeDrawMode(INACTIVE));
+    } else {
+      this.props.dispatch(changeDrawMode(null));
+    }
     this.props.dispatch(updateSelection(features.map(createRedo)));
   },
 

--- a/app/scripts/components/map/utils/constants.js
+++ b/app/scripts/components/map/utils/constants.js
@@ -4,3 +4,4 @@ export const INCOMPLETE = 'incomplete';
 export const EDITED = 'in progress';
 export const MULTIPLE = 'multiple';
 export const CONTINUE = 'continue';
+export const INACTIVE = 'inactive';

--- a/app/scripts/config/base.js
+++ b/app/scripts/config/base.js
@@ -1,5 +1,7 @@
 module.exports = {
   environment: 'development',
   baseUrl: 'http://138.197.97.15:4030',
-  existingRoadsSource: 'https://s3.amazonaws.com/vietbando/{z}/{x}/{y}.pbf'
+  existingRoadsSource: 'https://s3.amazonaws.com/vietbando/{z}/{x}/{y}.pbf',
+  initialZoom: 14,
+  minTileZoom: 13
 };

--- a/app/scripts/reducers/draw.js
+++ b/app/scripts/reducers/draw.js
@@ -1,9 +1,9 @@
 import { CHANGE_DRAW_MODE, TOGGLE_VISIBILITY } from '../actions';
-import { COMPLETE, INCOMPLETE, EDITED } from '../components/map/utils/constants';
+import { COMPLETE, INCOMPLETE, EDITED, INACTIVE } from '../components/map/utils/constants';
 import { initialZoom, minTileZoom } from '../config/';
 
 const initial = {
-  mode: null,
+  mode: initialZoom < minTileZoom ? INACTIVE : null,
   hidden: initialZoom < minTileZoom ? [COMPLETE, INCOMPLETE, EDITED] : []
 };
 

--- a/app/scripts/reducers/draw.js
+++ b/app/scripts/reducers/draw.js
@@ -1,9 +1,10 @@
 import { CHANGE_DRAW_MODE, TOGGLE_VISIBILITY } from '../actions';
 import { COMPLETE, INCOMPLETE, EDITED } from '../components/map/utils/constants';
+import { initialZoom, minTileZoom } from '../config/';
 
 const initial = {
   mode: null,
-  hidden: []
+  hidden: initialZoom < minTileZoom ? [COMPLETE, INCOMPLETE, EDITED] : []
 };
 
 const draw = (state = initial, action) => {

--- a/app/styles/_map.scss
+++ b/app/styles/_map.scss
@@ -19,6 +19,12 @@
   }
 }
 
+.menubar--disabled p {
+  padding: 0.3em 0;
+  font-weight: $base-font-bold;
+  text-align: center;
+}
+
 .disabled {
   img { opacity: 0.45; }
   pointer-events: none;
@@ -48,7 +54,7 @@
 
 .menubar {
   .button-base {
-    padding: .3em 1.5em .25em;
+    padding: .3em 1.5em .15em;
   }
 }
 

--- a/app/styles/_map.scss
+++ b/app/styles/_map.scss
@@ -19,10 +19,12 @@
   }
 }
 
-.menubar--disabled p {
-  padding: 0.3em 0;
-  font-weight: $base-font-bold;
+.menubar--disabled {
   text-align: center;
+}
+
+.menubar--disabled button {
+  display: inline-block;
 }
 
 .disabled {


### PR DESCRIPTION
Close #59 

@drewbo here's what I consider a draft for setting a minzoom. A known issue: if you are in the middle of drawing a line, and then zoom out before you "finish" the line, you won't trigger the UI to disable itself (as a result of crossing the minzoom limit), because:

1. zoom out triggers a return to `simple_select`
1. this causes gl draw to assume you've finished your line, which triggers a `draw:create` action
1. this fires our `handleCreate`, which sets the internal draw mode to `null` instead of `inactive`, thus showing the UI again.

Maybe I was being too cautious in using `props.draw.mode` here and should instead create another piece of state that would override it. Other thoughts are welcome as well.